### PR TITLE
Update to use a regex string

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -2,12 +2,7 @@ import chalk from 'chalk';
 
 export default function projector(text, delay) {
   let tape = text
-    .split(';')
-    .join('')
-    .split(',')
-    .join('')
-    .split('.')
-    .join('')
+    .replace(/[;,.]/g, '')
     .split(/\r\n/g)
     .join(' ')
     .split(' ')


### PR DESCRIPTION
Process the full text, replacing characters defined within the `[...]` of the regex with ''. Performs the same functionality as the split and join chain while using slightly less memory and being slightly more developer friendly.